### PR TITLE
회원의 닉네임 수정 API 구현

### DIFF
--- a/src/main/kotlin/com/susuhan/travelpick/domain/user/api/UserController.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/user/api/UserController.kt
@@ -1,0 +1,35 @@
+package com.susuhan.travelpick.domain.user.api
+
+import com.susuhan.travelpick.domain.user.dto.request.NicknameUpdateRequest
+import com.susuhan.travelpick.domain.user.dto.response.NicknameUpdateResponse
+import com.susuhan.travelpick.domain.user.service.UserCommandService
+import com.susuhan.travelpick.global.security.CustomUserDetails
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/v1/users")
+@RestController
+@Tag(name = "회원 관련 API")
+class UserController(
+    private val userCommandService: UserCommandService
+) {
+
+    @PatchMapping
+    fun updateNickname(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @Valid @RequestBody nicknameUpdateRequest: NicknameUpdateRequest
+    ): ResponseEntity<NicknameUpdateResponse> {
+        val userId = customUserDetails.userId.toLong()
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(userCommandService.updateNickname(userId, nicknameUpdateRequest))
+    }
+}

--- a/src/main/kotlin/com/susuhan/travelpick/domain/user/dto/request/NicknameUpdateRequest.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/user/dto/request/NicknameUpdateRequest.kt
@@ -1,0 +1,12 @@
+package com.susuhan.travelpick.domain.user.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class NicknameUpdateRequest(
+    @Schema(description = "수정할 회원의 닉네임")
+    @field:NotBlank(message = "닉네임은 공백이나 빈 값이 아니여야 합니다.")
+    @field:Size(max = 10, message = "닉네임은 10자 이하여야 합니다.")
+    val nickname: String
+)

--- a/src/main/kotlin/com/susuhan/travelpick/domain/user/dto/response/NicknameUpdateResponse.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/user/dto/response/NicknameUpdateResponse.kt
@@ -1,0 +1,21 @@
+package com.susuhan.travelpick.domain.user.dto.response
+
+import com.susuhan.travelpick.domain.user.entity.User
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class NicknameUpdateResponse (
+    @Schema(description = "회원의 프로필 사진 S3 url 경로")
+    val profileImageUrl: String,
+    @Schema(description = "회원의 이메일")
+    val email: String?,
+    @Schema(description = "회원의 닉네임")
+    val nickname: String,
+) {
+    companion object {
+        fun from(user: User): NicknameUpdateResponse {
+            return NicknameUpdateResponse(
+                user.profileImageUrl, user?.email, user.nickname!!
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/susuhan/travelpick/domain/user/entity/User.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/user/entity/User.kt
@@ -53,6 +53,10 @@ class User(
     @Column(name = "refresh_token")
     var refreshToken: String? = null
 
+    fun updateNickname(nickname: String) {
+        this.nickname = nickname
+    }
+
     fun updateRefreshToken(refreshToken: String) {
         this.refreshToken = refreshToken
     }

--- a/src/main/kotlin/com/susuhan/travelpick/domain/user/service/UserCommandService.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/user/service/UserCommandService.kt
@@ -1,0 +1,22 @@
+package com.susuhan.travelpick.domain.user.service
+
+import com.susuhan.travelpick.domain.user.dto.request.NicknameUpdateRequest
+import com.susuhan.travelpick.domain.user.dto.response.NicknameUpdateResponse
+import com.susuhan.travelpick.domain.user.exception.UserIdNotFoundException
+import com.susuhan.travelpick.domain.user.repository.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional(readOnly = true)
+@Service
+class UserCommandService(
+    private val userRepository: UserRepository
+) {
+
+    @Transactional
+    fun updateNickname(userId: Long, nicknameUpdateRequest: NicknameUpdateRequest): NicknameUpdateResponse {
+        var user = userRepository.findById(userId) ?: throw UserIdNotFoundException()
+        user.updateNickname(nicknameUpdateRequest.nickname)
+        return NicknameUpdateResponse.from(user)
+    }
+}


### PR DESCRIPTION
## 🔥 Issue

- Close #13

## ⚒ Task

- 회원의 닉네임을 수정하는 API 구현
- API의 응답 값은 마이페이지 조회 시 필요한 데이터
- (테스트 코드는 추후 작성 예정)

## 📄 Reference

- None
