### PR TITLE
여행 메이트로 추가할 회원 정보 조회 API

### DIFF
--- a/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/dto/response/ConfirmTravelPlaceListResponse.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/dto/response/ConfirmTravelPlaceListResponse.kt
@@ -14,8 +14,8 @@ data class ConfirmTravelPlaceListResponse(
         fun from(
             travelId: Long,
             travelDate: LocalDate,
-            travelPlaceList:
-            List<TravelPlaceDto>, oneDayBudget: Long
+            travelPlaceList: List<TravelPlaceDto>,
+            oneDayBudget: Long
         ) = ConfirmTravelPlaceListResponse(
             travelId,
             travelDate,

--- a/src/main/kotlin/com/susuhan/travelpick/domain/user/api/UserController.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/user/api/UserController.kt
@@ -3,6 +3,7 @@ package com.susuhan.travelpick.domain.user.api
 import com.susuhan.travelpick.domain.user.dto.request.NicknameUpdateRequest
 import com.susuhan.travelpick.domain.user.dto.response.NicknameCheckResponse
 import com.susuhan.travelpick.domain.user.dto.response.NicknameUpdateResponse
+import com.susuhan.travelpick.domain.user.dto.response.UserSearchResponse
 import com.susuhan.travelpick.domain.user.service.UserCommandService
 import com.susuhan.travelpick.domain.user.service.UserQueryService
 import com.susuhan.travelpick.global.security.CustomUserDetails
@@ -62,5 +63,19 @@ class UserController(
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(userQueryService.checkNicknameDuplicated(nickname))
+    }
+
+    @Operation(
+        summary = "여행 메이트로 추가할 회원 정보 조회",
+        description = "전달 받은 회원의 닉네임이 존재한다면 회원의 정보를 반환하고 존재하지 않으면 null로 반환합니다.",
+        security = [SecurityRequirement(name = "access-token")]
+    )
+    @GetMapping("/search")
+    fun search(
+        @NotBlank @Size(max = 10) @RequestParam nickname: String
+    ): ResponseEntity<UserSearchResponse> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(userQueryService.search(nickname))
     }
 }

--- a/src/main/kotlin/com/susuhan/travelpick/domain/user/dto/response/UserSearchResponse.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/user/dto/response/UserSearchResponse.kt
@@ -1,0 +1,18 @@
+package com.susuhan.travelpick.domain.user.dto.response
+
+import com.susuhan.travelpick.domain.user.entity.User
+
+data class UserSearchResponse(
+    val id: Long?,
+    val nickname: String?,
+    val profileImageUrl: String?
+) {
+
+    companion object {
+        fun from(user: User?) = UserSearchResponse(
+            user?.id,
+            user?.nickname,
+            user?.profileImageUrl
+        )
+    }
+}

--- a/src/main/kotlin/com/susuhan/travelpick/domain/user/entity/User.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/user/entity/User.kt
@@ -5,6 +5,7 @@ import com.susuhan.travelpick.domain.user.constant.Role
 import com.susuhan.travelpick.global.common.entity.BaseTimeEntity
 import com.susuhan.travelpick.global.common.util.ConstantUtils
 import jakarta.persistence.*
+import java.time.LocalDateTime
 
 @Table(name = "users")
 @Entity
@@ -52,6 +53,10 @@ class User(
     // TODO: redis로 관리할 예정
     @Column(name = "refresh_token")
     var refreshToken: String? = null
+
+    @Column(name = "delete_at")
+    var deleteAt: LocalDateTime? = null
+        protected set
 
     /**
      * 편의 메서드 시작

--- a/src/main/kotlin/com/susuhan/travelpick/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/user/repository/UserRepository.kt
@@ -3,7 +3,7 @@ package com.susuhan.travelpick.domain.user.repository
 import com.susuhan.travelpick.domain.user.entity.User
 import org.springframework.data.repository.Repository
 
-interface UserRepository : Repository<User, Long> {
+interface UserRepository : Repository<User, Long>, UserRepositoryQCustom {
 
     fun save(entity: User): User
 

--- a/src/main/kotlin/com/susuhan/travelpick/domain/user/repository/UserRepositoryQCustom.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/user/repository/UserRepositoryQCustom.kt
@@ -1,0 +1,8 @@
+package com.susuhan.travelpick.domain.user.repository
+
+import com.susuhan.travelpick.domain.user.entity.User
+
+interface UserRepositoryQCustom {
+    
+    fun findByNickname(nickname: String): User?
+}

--- a/src/main/kotlin/com/susuhan/travelpick/domain/user/repository/UserRepositoryQCustomImpl.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/user/repository/UserRepositoryQCustomImpl.kt
@@ -1,0 +1,23 @@
+package com.susuhan.travelpick.domain.user.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.susuhan.travelpick.domain.user.entity.QUser.user
+import com.susuhan.travelpick.domain.user.entity.User
+import org.springframework.stereotype.Repository
+
+@Repository
+class UserRepositoryQCustomImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+): UserRepositoryQCustom {
+
+    override fun findByNickname(nickname: String): User? {
+        return jpaQueryFactory
+            .select(user)
+            .from(user)
+            .where(
+                user.nickname.eq(nickname),
+                user.deleteAt.isNull
+            )
+            .fetchOne()
+    }
+}

--- a/src/main/kotlin/com/susuhan/travelpick/domain/user/service/UserQueryService.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/user/service/UserQueryService.kt
@@ -1,6 +1,7 @@
 package com.susuhan.travelpick.domain.user.service
 
 import com.susuhan.travelpick.domain.user.dto.response.NicknameCheckResponse
+import com.susuhan.travelpick.domain.user.dto.response.UserSearchResponse
 import com.susuhan.travelpick.domain.user.repository.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,5 +15,10 @@ class UserQueryService(
     fun checkNicknameDuplicated(nickname: String): NicknameCheckResponse {
         val isDuplicated = userRepository.existsByNickname(nickname)
         return NicknameCheckResponse.of(isDuplicated)
+    }
+
+    fun search(nickname: String): UserSearchResponse {
+        val user = userRepository.findByNickname(nickname)
+        return UserSearchResponse.from(user)
     }
 }


### PR DESCRIPTION
## 🔥 Issue

- Close #63 

## ⚒ Task

- 여행 메이트로 추가할 회원 정보 조회하는 API 구현
- 만약 회원이 존재하지 않는다면 null로 dto를 채워 반환

## 📄 Reference

- None
