### PR TITLE
여행 일정 순서 변경 API 구현

### DIFF
--- a/src/main/kotlin/com/susuhan/travelpick/domain/travelmate/dto/response/ParticipantMateInfoResponse.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/travelmate/dto/response/ParticipantMateInfoResponse.kt
@@ -14,7 +14,7 @@ data class ParticipantMateInfoResponse(
     companion object {
         fun from(travelMate: TravelMate) = ParticipantMateInfoResponse(
             travelMate.id!!,
-            travelMate.user?.nickname
+            travelMate.user.nickname
         )
     }
 }

--- a/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/api/TravelPlaceController.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/api/TravelPlaceController.kt
@@ -5,6 +5,7 @@ import com.susuhan.travelpick.domain.travelplace.dto.request.TravelPlaceCreateRe
 import com.susuhan.travelpick.domain.travelplace.dto.request.TravelPlaceUpdateRequest
 import com.susuhan.travelpick.domain.travelplace.dto.response.ConfirmTravelPlaceListResponse
 import com.susuhan.travelpick.domain.travelplace.dto.response.TravelPlaceCreateResponse
+import com.susuhan.travelpick.domain.travelplace.dto.response.TravelPlaceSequenceUpdateResponse
 import com.susuhan.travelpick.domain.travelplace.dto.response.TravelPlaceUpdateResponse
 import com.susuhan.travelpick.domain.travelplace.service.TravelPlaceCommandService
 import com.susuhan.travelpick.domain.travelplace.service.TravelPlaceQueryService
@@ -122,6 +123,33 @@ class TravelPlaceController(
             .status(HttpStatus.OK)
             .body(travelPlaceQueryService.getAllConfirmPlaceAddressList(
                 customUserDetails.getUserId(), travelId
+            ))
+    }
+
+    @Operation(
+        summary = "여행지 순서 변경 API",
+        description = """
+            여행지의 순서를 한 칸 위 / 한 칸 아래 / 최상단 / 최하위로 변경합니다.
+            [1] 한 칸 위로 이동: ?location=upper
+            [2] 한 칸 아래로 이동: ?location=lower
+            [3] 최상단으로 이동: ?location=top
+            [4] 최하단으로 이동: ?location=bottom
+            만약, 이미 최상단에 위치하는 여행지를 한 칸 위나 최상단으로 이동시키려고 하거나
+            이미 최하단에 위치하는 여행지를 한 칸 아래나 최하단으로 이동시키려고 하는 요청이라면 null을 반환합니다.
+        """,
+        security = [SecurityRequirement(name = "access-token")]
+    )
+    @PutMapping("/{travelId}/places/{travelPlaceId}/sequence")
+    fun updateTravelPlaceSequence(
+        @PathVariable(name = "travelId") travelId: Long,
+        @PathVariable(name = "travelPlaceId") travelPlaceId: Long,
+        @RequestParam(name = "travelDay") travelDay: Int,
+        @RequestParam(name = "location") location: String
+    ): ResponseEntity<TravelPlaceSequenceUpdateResponse?> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(travelPlaceCommandService.updateTravelPlaceSequence(
+                travelId, travelPlaceId, travelDay, location
             ))
     }
 }

--- a/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/dto/AddressInfo.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/dto/AddressInfo.kt
@@ -1,7 +1,14 @@
 package com.susuhan.travelpick.domain.travelplace.dto
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 data class AddressInfo(
+    @Schema(description = "여행 장소의 PK")
     val id: Long,
+
+    @Schema(description = "여행 장소의 우편 주소")
     val postcode: String,
+
+    @Schema(description = "여행 장소의 도로명 주소")
     val address: String
 )

--- a/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/dto/TravelPlaceDto.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/dto/TravelPlaceDto.kt
@@ -1,15 +1,31 @@
 package com.susuhan.travelpick.domain.travelplace.dto
 
 import com.susuhan.travelpick.domain.travelplace.entity.TravelPlace
+import io.swagger.v3.oas.annotations.media.Schema
 
 data class TravelPlaceDto(
+    @Schema(description = "여행 장소의 PK")
     val id: Long,
+
+    @Schema(description = "여행 장소의 여행 날짜")
     val travelDay: Int,
+
+    @Schema(description = "여행 장소의 이름")
     val name: String,
+
+    @Schema(description = "여행 장소의 우편 번호")
     val postcode: String,
+
+    @Schema(description = "여행 장소의 도로명 주소")
     val address: String,
+
+    @Schema(description = "여행 장소의 예산")
     val budget: Long,
+
+    @Schema(description = "여행 장소의 순서")
     val sequence: Long,
+
+    @Schema(description = "여행 장소의 참고 링크")
     val urlLink: String?
 ) {
 
@@ -22,7 +38,7 @@ data class TravelPlaceDto(
             travelPlace.address,
             travelPlace.budget,
             travelPlace.sequence,
-            travelPlace?.urlLink
+            travelPlace.urlLink
         )
     }
 }

--- a/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/dto/response/ConfirmTravelPlaceListResponse.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/dto/response/ConfirmTravelPlaceListResponse.kt
@@ -1,12 +1,20 @@
 package com.susuhan.travelpick.domain.travelplace.dto.response
 
 import com.susuhan.travelpick.domain.travelplace.dto.TravelPlaceDto
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
 data class ConfirmTravelPlaceListResponse(
+    @Schema(description = "여행지의 PK")
     val travelId: Long,
+
+    @Schema(description = "여행 장소의 여행 날짜")
     val travelDate: LocalDate,
+
+    @Schema(description = "여행 장소 목록")
     val travelPlaceList: List<TravelPlaceDto>,
+
+    @Schema(description = "여행 장소 목록의 하루 총 예산")
     val oneDayBudget: Long
 ) {
 

--- a/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/dto/response/TravelPlaceSequenceUpdateResponse.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/dto/response/TravelPlaceSequenceUpdateResponse.kt
@@ -1,0 +1,16 @@
+package com.susuhan.travelpick.domain.travelplace.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class TravelPlaceSequenceUpdateResponse(
+    @Schema(description = "여행지의 PK")
+    val travelId: Long,
+
+    @Schema(description = "여행지의 여행 날짜")
+    val travelDay: Int
+) {
+
+    companion object {
+        fun of(travelId: Long, travelDay: Int) = TravelPlaceSequenceUpdateResponse(travelId, travelDay)
+    }
+}

--- a/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/dto/response/TravelPlaceSequenceUpdateResponse.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/dto/response/TravelPlaceSequenceUpdateResponse.kt
@@ -6,7 +6,7 @@ data class TravelPlaceSequenceUpdateResponse(
     @Schema(description = "여행지의 PK")
     val travelId: Long,
 
-    @Schema(description = "여행지의 여행 날짜")
+    @Schema(description = "여행 장소의 여행 날짜")
     val travelDay: Int
 ) {
 

--- a/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/entity/TravelPlace.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/entity/TravelPlace.kt
@@ -88,6 +88,10 @@ class TravelPlace(
         this.urlLink = urlLink
     }
 
+    fun updateSequence(sequence: Long) {
+        this.sequence = sequence
+    }
+
     fun softDelete() {
         this.deleteAt = LocalDateTime.now()
     }

--- a/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/repository/TravelPlaceRepositoryQCustom.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/repository/TravelPlaceRepositoryQCustom.kt
@@ -16,4 +16,12 @@ interface TravelPlaceRepositoryQCustom {
     fun findTotalBudget(travelId: Long): Long
 
     fun findPostcodeAndAddress(travelId: Long): List<AddressInfo>
+
+    fun incrementSequence(sequence: Long)
+
+    fun decrementSequence(sequence: Long)
+
+    fun incrementAllSequence(sequence: Long)
+
+    fun decrementAllSequence(sequence: Long)
 }

--- a/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/repository/TravelPlaceRepositoryQCustomImpl.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/repository/TravelPlaceRepositoryQCustomImpl.kt
@@ -84,4 +84,36 @@ class TravelPlaceRepositoryQCustomImpl(
             )
             .fetch()
     }
+
+    override fun incrementSequence(sequence: Long) {
+        jpaQueryFactory
+            .update(travelPlace)
+            .set(travelPlace.sequence, travelPlace.sequence.add(1))
+            .where(travelPlace.sequence.eq(sequence))
+            .execute()
+    }
+
+    override fun decrementSequence(sequence: Long) {
+        jpaQueryFactory
+            .update(travelPlace)
+            .set(travelPlace.sequence, travelPlace.sequence.subtract(1))
+            .where(travelPlace.sequence.eq(sequence))
+            .execute()
+    }
+
+    override fun incrementAllSequence(sequence: Long) {
+        jpaQueryFactory
+            .update(travelPlace)
+            .set(travelPlace.sequence, travelPlace.sequence.add(1))
+            .where(travelPlace.sequence.lt(sequence))
+            .execute()
+    }
+
+    override fun decrementAllSequence(sequence: Long) {
+        jpaQueryFactory
+            .update(travelPlace)
+            .set(travelPlace.sequence, travelPlace.sequence.subtract(1))
+            .where(travelPlace.sequence.gt(sequence))
+            .execute()
+    }
 }

--- a/src/main/kotlin/com/susuhan/travelpick/domain/user/dto/response/LoginUserInfoResponse.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/user/dto/response/LoginUserInfoResponse.kt
@@ -1,18 +1,24 @@
 package com.susuhan.travelpick.domain.user.dto.response
 
 import com.susuhan.travelpick.domain.user.entity.User
+import io.swagger.v3.oas.annotations.media.Schema
 
 class LoginUserInfoResponse(
+    @Schema(description = "회원의 PK")
     val id: Long?,
+
+    @Schema(description = "회원의 닉네임")
     val nickname: String?,
+
+    @Schema(description = "회원의 프로필 사진 S3 url 경로")
     val profileImageUrl: String?
 ) {
 
     companion object {
         fun from(user: User) = LoginUserInfoResponse(
-            user?.id,
-            user?.nickname,
-            user?.profileImageUrl
+            user.id,
+            user.nickname,
+            user.profileImageUrl
         )
     }
 }

--- a/src/main/kotlin/com/susuhan/travelpick/domain/user/dto/response/NicknameUpdateResponse.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/user/dto/response/NicknameUpdateResponse.kt
@@ -6,8 +6,10 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class NicknameUpdateResponse (
     @Schema(description = "회원의 프로필 사진 S3 url 경로")
     val profileImageUrl: String,
+
     @Schema(description = "회원의 이메일")
     val email: String?,
+
     @Schema(description = "회원의 닉네임")
     val nickname: String?,
 ) {
@@ -15,8 +17,8 @@ data class NicknameUpdateResponse (
     companion object {
         fun from(user: User) = NicknameUpdateResponse(
             user.profileImageUrl,
-            user?.email,
-            user?.nickname
+            user.email,
+            user.nickname
         )
     }
 }

--- a/src/main/kotlin/com/susuhan/travelpick/domain/user/dto/response/UserSearchByNicknameResponse.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/user/dto/response/UserSearchByNicknameResponse.kt
@@ -1,10 +1,16 @@
 package com.susuhan.travelpick.domain.user.dto.response
 
 import com.susuhan.travelpick.domain.user.entity.User
+import io.swagger.v3.oas.annotations.media.Schema
 
 data class UserSearchByNicknameResponse(
+    @Schema(description = "회원의 PK")
     val id: Long?,
+
+    @Schema(description = "회원의 닉네임")
     val nickname: String?,
+
+    @Schema(description = "회원의 프로필 사진 S3 url 경로")
     val profileImageUrl: String?
 ) {
 


### PR DESCRIPTION
## 🔥 Issue

- Close #77

## ⚒ Task

- 여행 장소의 순서를 `한 칸 위` / `최상단` / `한 칸 아래` / `최하단`으로 변경하는 API 구현
- (만약, 이미 최상단에 위치하는 여행지를 한 칸 위나 최상단으로 이동시키려고 하거나 이미 최하단에 위치하는 여행지를 한 칸 아래나 최하단으로 이동시키려고 하는 요청이라면 null을 반환)
- swagger 문서에 빠뜨린 dto에 대한 설명 추가

## 📄 Reference

- None
