### PR TITLE
여행 장소 순서의 DB 유니크 제약 조건 제거

### DIFF
--- a/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/entity/TravelPlace.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/entity/TravelPlace.kt
@@ -49,7 +49,7 @@ class TravelPlace(
     var budget: Long = budget // 1인당 예산
         protected set
 
-    @Column(name = "sequence", unique = true, nullable = false)
+    @Column(name = "sequence", nullable = false)
     var sequence: Long = sequence
         protected set
 

--- a/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/service/TravelPlaceCommandService.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/service/TravelPlaceCommandService.kt
@@ -73,6 +73,8 @@ class TravelPlaceCommandService(
             ?: throw TravelPlaceIdNotFoundException()
 
         travelPlace.softDelete()
+        
+        travelPlaceRepository.decrementAllSequence(travelPlace.sequence)
     }
 
     @Transactional


### PR DESCRIPTION
## 🔥 Issue

- Close #79

## ⚒ Task

- 기존에 존재하는 여행 장소 순서의 DB 유니크 제약 조건 제거
- 여행 장소 soft delete를 할 때 삭제한 장소의 다음 장소들의 순서를 1씩 감소

## 📄 Reference

- None
