### PR TITLE
그룹 알림 메시지 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/susuhan/travelpick/domain/notification/api/NotificationController.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/notification/api/NotificationController.kt
@@ -1,0 +1,40 @@
+package com.susuhan.travelpick.domain.notification.api
+
+import com.susuhan.travelpick.domain.notification.dto.GroupMessageInfoResponse
+import com.susuhan.travelpick.domain.notification.service.NotificationCommandService
+import com.susuhan.travelpick.global.security.CustomUserDetails
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/v1/notifications")
+@RestController
+@Tag(name = "여행 그룹 메시지 관련 API")
+class NotificationController(
+    private val notificationCommandService: NotificationCommandService
+) {
+
+    @Operation(
+        summary = "그룹 메시지 목록 조회",
+        description = "여행지 그룹의 자동 생성 메시지 목록을 조회합니다.",
+        security = [SecurityRequirement(name = "access-token")]
+    )
+    @PutMapping("/travels/{travelId}")
+    fun getGroupMessageList(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @PathVariable("travelId") travelId: Long
+    ): ResponseEntity<List<GroupMessageInfoResponse>> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(notificationCommandService.getGroupMessageList(
+                customUserDetails.getUserId(), travelId
+            ))
+    }
+}

--- a/src/main/kotlin/com/susuhan/travelpick/domain/notification/dto/GroupMessageInfoResponse.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/notification/dto/GroupMessageInfoResponse.kt
@@ -1,0 +1,46 @@
+package com.susuhan.travelpick.domain.notification.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.*
+import com.susuhan.travelpick.domain.notification.entity.Notification
+import com.susuhan.travelpick.domain.travelplace.dto.TravelPlaceMessageInfo
+import com.susuhan.travelpick.domain.user.dto.UserProfileInfo
+import java.time.LocalDateTime
+
+@JsonInclude(Include.NON_NULL)
+data class GroupMessageInfoResponse(
+    val id: Long,
+    val createAt: LocalDateTime,
+    val message: String,
+    val sendUserProfileInfo: UserProfileInfo,
+    val travelPlaceMessageInfo: TravelPlaceMessageInfo?,
+    val travelMateMessageInfo: UserProfileInfo?,
+    val isMine: Boolean
+) {
+
+    companion object {
+        fun from(notification: Notification) = GroupMessageInfoResponse(
+            notification.id!!,
+            notification.createAt,
+            "${notification.sendUser.nickname}${notification.travelAction.message}",
+            UserProfileInfo(
+                notification.sendUser.nickname,
+                notification.sendUser.profileImageUrl
+            ),
+            notification.travelPlace?.let {
+                TravelPlaceMessageInfo(
+                    it.travel.startAt.plusDays((it.travelDay - 1).toLong()),
+                    it.travelDay,
+                    it.name
+                )
+            },
+            notification.travelMate?.let {
+                UserProfileInfo(
+                    it.user.nickname,
+                    it.user.profileImageUrl
+                )
+            },
+            notification.receiveUserId == notification.sendUser.id
+        )
+    }
+}

--- a/src/main/kotlin/com/susuhan/travelpick/domain/notification/repository/NotificationRepository.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/notification/repository/NotificationRepository.kt
@@ -3,7 +3,7 @@ package com.susuhan.travelpick.domain.notification.repository
 import com.susuhan.travelpick.domain.notification.entity.Notification
 import org.springframework.data.repository.Repository
 
-interface NotificationRepository : Repository<Notification, Long> {
+interface NotificationRepository : Repository<Notification, Long>, NotificationRepositoryQCustom {
 
     fun saveAll(entities: Iterable<Notification>): List<Notification>
 }

--- a/src/main/kotlin/com/susuhan/travelpick/domain/notification/repository/NotificationRepositoryQCustom.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/notification/repository/NotificationRepositoryQCustom.kt
@@ -1,0 +1,8 @@
+package com.susuhan.travelpick.domain.notification.repository
+
+import com.susuhan.travelpick.domain.notification.entity.Notification
+
+interface NotificationRepositoryQCustom {
+
+    fun findNotifications(userId: Long, travelId: Long): List<Notification>
+}

--- a/src/main/kotlin/com/susuhan/travelpick/domain/notification/repository/NotificationRepositoryQCustomImpl.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/notification/repository/NotificationRepositoryQCustomImpl.kt
@@ -1,0 +1,41 @@
+package com.susuhan.travelpick.domain.notification.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.susuhan.travelpick.domain.notification.entity.Notification
+import com.susuhan.travelpick.domain.notification.entity.QNotification.*
+import com.susuhan.travelpick.domain.travel.entity.QTravel.travel
+import com.susuhan.travelpick.domain.travelmate.entity.QTravelMate.travelMate
+import com.susuhan.travelpick.domain.travelplace.entity.QTravelPlace.travelPlace
+import com.susuhan.travelpick.domain.user.entity.QUser
+import org.springframework.stereotype.Repository
+
+@Repository
+class NotificationRepositoryQCustomImpl (
+    private val jpaQueryFactory: JPAQueryFactory
+) : NotificationRepositoryQCustom {
+
+    override fun findNotifications(userId: Long, travelId: Long): List<Notification> {
+        // 그룹 메시지 목록 조회 시 isRead 필드를 true로 업데이트
+        jpaQueryFactory.update(notification)
+            .set(notification.isRead, true)
+            .where(
+                notification.receiveUserId.eq(userId),
+                notification.travelId.eq(travelId),
+            )
+            .execute()
+
+        return jpaQueryFactory
+            .select(notification)
+            .from(notification)
+            .innerJoin(notification.sendUser, QUser("sendUser")).fetchJoin()
+            .leftJoin(notification.travelPlace, travelPlace).fetchJoin()
+            .leftJoin(notification.travelPlace.travel, travel).fetchJoin()
+            .leftJoin(notification.travelMate, travelMate).fetchJoin()
+            .leftJoin(notification.travelMate.user, QUser("travelMateUser")).fetchJoin()
+            .where(
+                notification.receiveUserId.eq(userId),
+                notification.travelId.eq(travelId)
+            )
+            .fetch()
+    }
+}

--- a/src/main/kotlin/com/susuhan/travelpick/domain/notification/service/NotificationCommandService.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/notification/service/NotificationCommandService.kt
@@ -1,8 +1,12 @@
 package com.susuhan.travelpick.domain.notification.service
 
+import com.susuhan.travelpick.domain.notification.dto.GroupMessageInfoResponse
 import com.susuhan.travelpick.domain.notification.entity.Notification
 import com.susuhan.travelpick.domain.notification.repository.NotificationRepository
+import com.susuhan.travelpick.domain.travel.exception.TravelIdNotFoundException
+import com.susuhan.travelpick.domain.travel.repository.TravelRepository
 import com.susuhan.travelpick.domain.travelmate.entity.TravelMate
+import com.susuhan.travelpick.domain.travelmate.exception.TravelMateNotFoundException
 import com.susuhan.travelpick.domain.travelmate.repository.TravelMateRepository
 import com.susuhan.travelpick.domain.travelplace.entity.TravelPlace
 import com.susuhan.travelpick.domain.user.exception.UserIdNotFoundException
@@ -14,6 +18,7 @@ import org.springframework.stereotype.Service
 @Service
 class NotificationCommandService(
     private val notificationRepository: NotificationRepository,
+    private val travelRepository: TravelRepository,
     private val travelMateRepository: TravelMateRepository,
     private val userRepository: UserRepository,
 ) {
@@ -40,5 +45,19 @@ class NotificationCommandService(
             ) }
 
         notificationRepository.saveAll(notificationList)
+    }
+
+    @Transactional
+    fun getGroupMessageList(userId: Long, travelId: Long): List<GroupMessageInfoResponse> {
+        if (!travelRepository.existsNotDeletedPlannedTravel(travelId)) {
+            throw TravelIdNotFoundException()
+        }
+
+        if (!travelMateRepository.existsNotDeletedMate(userId, travelId)) {
+            throw TravelMateNotFoundException(userId)
+        }
+
+        return notificationRepository.findNotifications(userId, travelId)
+            .map { GroupMessageInfoResponse.from(it) }
     }
 }

--- a/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/dto/TravelPlaceMessageInfo.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/dto/TravelPlaceMessageInfo.kt
@@ -1,0 +1,11 @@
+package com.susuhan.travelpick.domain.travelplace.dto
+
+import java.time.LocalDate
+
+data class TravelPlaceMessageInfo(
+    val travelDate: LocalDate,
+    val travelDay: Int,
+    val name: String,
+    // TODO: 추가된 경로에 대한 필드 추가
+    // TODO: 카테고리 필드 추가
+)

--- a/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/entity/TravelPlace.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/travelplace/entity/TravelPlace.kt
@@ -61,6 +61,9 @@ class TravelPlace(
     var deleteAt: LocalDateTime? = null
         protected set
 
+    // TODO: 추가된 경로에 대한 필드 추가
+    // TODO: 카테고리 필드 추가
+
     /**
      * 편의 메서드 시작
      */

--- a/src/main/kotlin/com/susuhan/travelpick/domain/user/dto/UserProfileInfo.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/user/dto/UserProfileInfo.kt
@@ -1,0 +1,11 @@
+package com.susuhan.travelpick.domain.user.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+class UserProfileInfo(
+    @Schema(description = "회원의 닉네임")
+    val nickname: String?,
+
+    @Schema(description = "회원의 프로필 사진 S3 url 경로")
+    val profileImageUrl: String
+)


### PR DESCRIPTION
## 🔥 Issue

- Close #82 

## ⚒ Task

- 각 여행지마다 하나씩 존재하는 그룹 알림방의 자동 생성 메시지를 조회하는 API를 구현

## 📄 Reference

- None
