### PR TITLE
동일한 여행 메이트가 추가되지 않도록 로직 추가

### DIFF
--- a/src/main/kotlin/com/susuhan/travelpick/domain/travelmate/service/TravelMateCommandService.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/domain/travelmate/service/TravelMateCommandService.kt
@@ -52,6 +52,7 @@ class TravelMateCommandService(
         TravelPolicy.isTravelLeader(userId, travel.leaderId)
 
         val travelMateList = userRepository.findAllNotDeletedUserById(request.userIds)
+            .filter { user -> !travelMateRepository.existsNotDeletedMate(user.id!!, travelId) }
             .map { user -> request.toEntity(user, travel) }
 
         return travelMateRepository.saveAll(travelMateList)


### PR DESCRIPTION
## 🔥 Issue

- Close #84

## ⚒ Task

- 여행지에 대해 이미 추가된 여행 메이트가 다시 추가되지 않도록 `filtering`하는 코드 추가

## 📄 Reference

- None
