### PR TITLE
@EnableConfigurationProperties 설정 파일로 분리

### DIFF
--- a/src/main/kotlin/com/susuhan/travelpick/TravelPickApplication.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/TravelPickApplication.kt
@@ -1,11 +1,8 @@
 package com.susuhan.travelpick
 
-import com.susuhan.travelpick.global.properties.JwtProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 
-@EnableConfigurationProperties(JwtProperties::class)
 @SpringBootApplication
 class TravelPickApplication
 

--- a/src/main/kotlin/com/susuhan/travelpick/global/config/PropertiesConfig.kt
+++ b/src/main/kotlin/com/susuhan/travelpick/global/config/PropertiesConfig.kt
@@ -1,0 +1,11 @@
+package com.susuhan.travelpick.global.config
+
+import com.susuhan.travelpick.global.properties.JwtProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@EnableConfigurationProperties(
+    JwtProperties::class,
+)
+@Configuration
+class PropertiesConfig


### PR DESCRIPTION
## 🔥 Issue

- Close #101 

## ⚒ Task

- 프로젝트를 계속 진행하면서 @EnableConfigurationProperties로 빈으로 등록할 파일이 계속만들어질 것 같아
- 더 나은 유지보수를 하고자 기존의 코드를 별도의 설정 파일로 분리해서 관리

## 📄 Reference

- None
